### PR TITLE
[WIP]商品詳細表示サーバーサイド

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:destory]
+  before_action :set_item, only: [:destory, :show, :edit]
 
   def index
     @items = Item.includes(:images)
@@ -46,6 +46,9 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+  end
+
   def destory
     @item.destory
     redirect_to root_path
@@ -60,8 +63,5 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
-  def show
-
-  end
 
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -29,9 +29,9 @@
             = link_to "削除", item_path(@item.id), method: :delete
         - else
           %li.lists__right--item-login
-            = link_to "ログイン", new_user_registration_path
+            = link_to "ログイン", new_user_session_path
           %li.lists__right--item-new
-            = link_to "新規会員登録", new_user_session_path
+            = link_to "新規会員登録", new_user_registration_path
             = link_to "購入画面に進む",root_path
 %nav.bread-line
   %ul

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -21,10 +21,18 @@
           = link_to "#" do
             ブランド
       %ul.lists__right
-        %li.lists__right--item-login
-          = link_to "ログイン", new_user_registration_path
-        %li.lists__right--item-new
-          = link_to "新規会員登録", new_user_session_path
+        - if user_signed_in? && current_user.id == @item.seller_id
+
+          %li.lists__right__item-new
+            = link_to "マイページ", "/users/show"
+            = link_to "編集", edit_item_path(@item.id)
+            = link_to "削除", item_path(@item.id), method: :delete
+        - else
+          %li.lists__right--item-login
+            = link_to "ログイン", new_user_registration_path
+          %li.lists__right--item-new
+            = link_to "新規会員登録", new_user_session_path
+            = link_to "購入画面に進む",root_path
 %nav.bread-line
   %ul
     %li
@@ -54,30 +62,33 @@
     .main__content--right
       .view
         .view__item
-          %h2.view__item--box product3
+          %h2.view__item--box
+            = @item.name
           .view__item--body
             %ul
               %li
-                = image_tag 'https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png' 
+                = image_tag @item.images.first.url.url
                 %ul
                   %li
-                    = image_tag 'https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png'
+                    = image_tag @item.images.first.url.url
                   %li
-                    = image_tag 'https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/14/a001.png'
+                    = image_tag @item.images.second.url.url
                   %li
-                    = image_tag 'https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/15/a003.png'
+                    = image_tag @item.images.third.url.url
           .item-price
-            %span.price ¥30000
+            %span.price
+              = @item.price
             .item-price__detail
               %span.tax (税込み)
               %span.sent 送料込み
           .item-box
-            親譲りの無鉄砲で小供の時から損ばかりしている。小学校に居る時分学校の二階から飛び降りて一週間ほど腰を抜かした事がある。なぜそんな無闇をしたと聞く人があるかも知れぬ。別段深い理由でもない。新築の二階から首を出していたら、同級生の一人が冗談に、いくら威張っても、そこから飛び降りる事は出来まい。弱虫やーい。と囃したからである。小使に負ぶさって帰って来た時、おやじが大きな眼をして二階ぐらいから飛び降りて腰
+            = @item.introduction
           .table
             %table
               %tr
                 %th 出品者
-                %td hoge
+                %td
+                  = User.find(@item.seller_id).nickname
               %tr
                 %th カテゴリー
                 %td
@@ -92,23 +103,27 @@
               %tr
                 %th ブランド
                 %td
+                  = @item.brand
               %tr
                 %th 商品サイズ
                 %td
               %tr
                 %th 商品の状態
-                %td 未使用に近い
+                %td
+                  = @item.item_status.name
               %tr
                 %th 配送料の負担
-                %td 送料込み(出品者負担)
+                %td
+                  = @item.shipment_fee.name
               %tr 
                 %th 発送元の地域
                 %td
                   = link_to "#" do
-                    岩手県
+                    = @item.shipment_pref.name
               %tr
                 %th 発送日の目安
-                %td 4~7日で目安
+                %td
+                  = @item.shipment_date.name
           .option
             %ul
               %li#likebtn.optional-btn.likebtn


### PR DESCRIPTION
#What
商品詳細表示機能実装
＃Why
商品一覧から商品詳細表示を閲覧することができる
出品者は出品物の編集と削除のリンクに入ることができる
出品者以外は出品物の購入リンクに入ることができる
https://gyazo.com/4cde58383f0f26bd1cdd7ed67c844e00
https://gyazo.com/fa11db306a53de6e86b7b558deb82272
https://gyazo.com/9210973e2d91b81b6ad41953b5a7bd9e
https://gyazo.com/7a8614e83f0a068e2ada29bcfda4b577
※購入ページ未実装のため、購入のリンクは仮でroot_pathにしてます