### PR TITLE
商品編集機能の実装(サーバーサイド)及びカテゴリ機能の実装

### DIFF
--- a/app/assets/javascripts/edit.js
+++ b/app/assets/javascripts/edit.js
@@ -1,0 +1,55 @@
+$(function(){
+  const buildFileField = (num)=> {
+    const html = `<div data-index="${num}" class="js-file_group">
+                    <label data-index="${num}" for="item_item_images_attributes_${num}_url">
+                      <input class="js-file" type="file"
+                      name="item[item_images_attributes][${num}][url]"
+                      id="item_item_images_attributes_${num}_url">
+                    </label>
+                    <span class="js-remove">削除</div>
+                  </div>`;
+    return html;
+  }
+  const buildImg = (index, url)=> {
+    const html = `<img id = "image-${index}" data-index="${index}" src="${url}" width="100px" height="100px">`;
+    return html;
+  }
+
+
+  let fileIndex = [1,2,3,4,5,6,7,8,9,10];
+  lastIndex = $('.js-file_group:last').data('index');
+  fileIndex.splice(0, lastIndex);
+
+  $('.hidden-destroy').hide();
+
+  $('#image-box').on('change', '.js-file', function(e) {
+    const targetIndex = $(this).parent().data('index');
+    const file = e.target.files[0];
+    const blobUrl = window.URL.createObjectURL(file);
+    if (img = $(`img[data-index="${targetIndex}"]`)[0]) {
+      img.setAttribute('url', blobUrl);
+    } else {  
+      $('#previews').append(buildImg(targetIndex, blobUrl));
+      $('#file-box').append(buildFileField(fileIndex[0]));
+      fileIndex.shift();
+      fileIndex.push(fileIndex[fileIndex.length - 1] + 1);
+    }
+    if (fileIndex.length == 10) {
+      $(".js-file_group").css('display', 'none')   
+    }
+  });
+
+  $('#image-box').on('click', '.js-remove', function() {
+    const targetIndex = $(this).parent().data('index');
+    var targetCheckBox = "#destroy-" + targetIndex;
+    const hiddenCheck = $(targetCheckBox);
+    if (hiddenCheck.length) {
+      hiddenCheck.prop('checked', true);
+    }
+    var id_str = '#image-' + targetIndex;
+    var isExist = $(id_str).length;
+    if(isExist) $(this).parent().remove();
+    $(id_str).remove();
+    if ($('.js-file').length == 0) $('#file-box').append(buildFileField(fileIndex[0]));
+  });
+});

--- a/app/assets/javascripts/edit.js
+++ b/app/assets/javascripts/edit.js
@@ -35,21 +35,17 @@ $(function(){
       fileIndex.push(fileIndex[fileIndex.length - 1] + 1);
     }
     if (fileIndex.length == 10) {
-      $(".js-file_group").css('display', 'none')   
+      $("#item_item_images_attributes_11_url").css('display', 'none')   
     }
   });
 
   $('#image-box').on('click', '.js-remove', function() {
     const targetIndex = $(this).parent().data('index');
-    var targetCheckBox = "#destroy-" + targetIndex;
-    const hiddenCheck = $(targetCheckBox);
-    if (hiddenCheck.length) {
-      hiddenCheck.prop('checked', true);
-    }
-    var id_str = '#image-' + targetIndex;
-    var isExist = $(id_str).length;
-    if(isExist) $(this).parent().remove();
-    $(id_str).remove();
-    if ($('.js-file').length == 0) $('#file-box').append(buildFileField(fileIndex[0]));
+    const hiddenCheck = $(`input[data-index="${targetIndex}"].hidden-destroy`);
+    if (hiddenCheck) hiddenCheck.prop('checked', true);
+
+    $(this).parent().remove();
+    $(`img[data-index="${targetIndex}"]`).remove();
+    if ($('.js-file').length == 0) $('#image-box').append(buildFileField(fileIndex[0]));
   });
 });

--- a/app/assets/stylesheets/items/_new.scss
+++ b/app/assets/stylesheets/items/_new.scss
@@ -24,8 +24,9 @@
       .exhibision__content__box__image {
         border-bottom: 1px solid #F5F5F5;
         min-height: 200px;
-        max-height: 420px;
+        max-height: 820px;
         width: 100%;
+        margin-bottom :20px;
         &--name {
           @include name;
           span {
@@ -81,7 +82,7 @@
       }
       .exhibision__content__box__detail {
         border-bottom: 1px solid #F5F5F5;
-        max-height: 700pzpx;
+        max-height: 700px;
         min-width: 350px;
         width: 100%;
         p {
@@ -186,6 +187,20 @@
           cursor: pointer;
         }
       }
+    }
+  }
+}
+
+#file-box{
+  .js-file_group{
+    input {
+      margin: 3px;
+      font-size: 14px;
+    }
+    .js-remove{
+      @include require;
+      cursor: pointer;
+      padding: 3px;
     }
   }
 }

--- a/app/assets/stylesheets/items/_show.scss
+++ b/app/assets/stylesheets/items/_show.scss
@@ -180,22 +180,20 @@
                   img{
                     object-fit: cover;
                     height: 346px;
-                    width: 100%;
+                    width: auto;
                     vertical-align: bottom;
                   }
-                  ul{
-                    display: flex;
+                  .image-prev{
+                    width: 620px;
+                    overflow: scroll;
                     justify-content: center;
-                    margin-top: 10px;
-                    li{
-                      width: 25%;
-                      margin: 0 10px 0 0;
-                      img{
-                        object-fit: cover;
-                        height: 100px;
-                      }
+                    display: flex;
+                    img {
+                      width: 100px;
+                      height: 100px;
+                      margin: 3px;
                     }
-                  }
+                  }  
                 }
               }
             }

--- a/app/assets/stylesheets/items/_show.scss
+++ b/app/assets/stylesheets/items/_show.scss
@@ -189,8 +189,8 @@
                     justify-content: center;
                     display: flex;
                     img {
-                      width: 100px;
-                      height: 100px;
+                      width: 110px;
+                      height: 110px;
                       margin: 3px;
                     }
                   }  

--- a/app/assets/stylesheets/items/index.scss
+++ b/app/assets/stylesheets/items/index.scss
@@ -343,10 +343,11 @@ body{
           }
         }
         .product-lists{
-          width: 780px;
+          width: 100%;
           margin: 26px auto;
           display: flex;
           justify-content: space-around;
+          overflow: scroll;
           .product-list{
             width: 220px;
             display: inline-block;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:destory]
+  before_action :set_item, only: [:edit, :update, :show, :destory]
 
   def index
     @items = Item.includes(:images)
@@ -36,15 +36,25 @@ class ItemsController < ApplicationController
   end
 
   def edit
+    @category = Category.all.order("ancestry,id").limit(13)
+    @category_parent_array = Category.where(ancestry: nil)
+    @category_child_array = @item.category.parent.parent.children
+    @category_grandchild_array = @item.category.parent.children
   end
 
   def update
     if @item.update(item_params)
+      flash[:notice] = '編集できました'
       redirect_to root_path
     else
       render :edit
+      flash[:alert] = '編集できませんでした'
     end
   end
+
+  def show
+    @category = Category.all.order("ancestry,id").limit(13)
+  end  
 
   def destory
     @item.destory
@@ -59,9 +69,4 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
-
-  def show
-
-  end
-
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,7 +25,7 @@ class ItemsController < ApplicationController
 
   def create
     @category = Category.all.order("ancestry,id").limit(13)
-    @item = Item.new(item_params)
+    @item = Item.new(create_params)
     if @item.save
       flash[:notice] = '出品できました'
       redirect_to root_path
@@ -40,16 +40,14 @@ class ItemsController < ApplicationController
     @category_parent_array = Category.where(ancestry: nil)
     @category_child_array = @item.category.parent.parent.children
     @category_grandchild_array = @item.category.parent.children
-
   end
 
   def update
     if @item.update(item_params)
-      flash[:notice] = '編集できました'
-      redirect_to root_path
+      redirect_to root_path, notice: '編集完了しました'
     else
-      render :edit
       flash[:alert] = '編集できませんでした'
+      redirect_to action: "edit"
     end
   end
 
@@ -57,7 +55,7 @@ class ItemsController < ApplicationController
     @category = Category.all.order("ancestry,id").limit(13)
   end  
 
-def destroy
+  def destroy
     if user_signed_in? && current_user.id == @item.seller_id
       if @item.destroy
         redirect_to root_path, notice: '削除が完了しました'

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,0 +1,93 @@
+.exhibision
+  .exhibision__top
+    =render "users/logo"
+
+  .exhibision__content
+    = form_with model: @item do |f|
+      .exhibision__content__box
+        .exhibision__content__box__image
+          .exhibision__content__box__image--name
+            出品画像
+            %span 必須
+          %p 最大10枚までアップロードできます
+          #image-box
+            #previews
+              - if @item.persisted?
+                - @item.images.each_with_index do |image, i|
+                  - id_str = 'image-' + (i).to_s
+                  = image_tag image.url.url, id: id_str ,data: {index: i}, width: '100', height: '100'
+            #file-box
+              = f.fields_for :images do |image|
+                .js-file_group{data: {index: image.index}}
+
+                  = image.label :image, data: {index: image.index} do
+                    = image.file_field :image, class: 'js-file '
+                  %span.js-remove 削除
+
+                - if @item.persisted?
+                  - destroy_id_str = 'destroy-' + (image.index).to_s
+                  = image.check_box :_destroy, data: {index: image.index}, class: 'hidden-destroy', id: destroy_id_str
+
+              - if @item.persisted?
+                - lastIndex = @item.images.count
+                .js-file_group{"data-index": "#{lastIndex}"}
+                  = f.label :image, data: {index: lastIndex} do
+                    = f.file_field :url, name: "item[images_attributes][#{lastIndex}][url]", class: 'js-file '
+                  %span.js-remove 削除
+
+        .exhibision__content__box--item
+          .exhibision__content__box--item--name
+            商品名
+            %span 必須
+          .exhibision__content__box--item--form
+            = f.text_field :name, class:"exhibision__content__box--item--form--input", placeholder: "40字まで"
+          .exhibision__content__box--item--name
+            商品の説明
+            %span 必須
+          .exhibision__content__box--item--text
+            = f.text_area :introduction, class:"exhibision__content__box__item-illustration", placeholder: "商品の説明(必須1,000文字以内)\n(色、素材、重さ、定価、注意点など)\n\n例)2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。"
+        .exhibision__content__box__detail
+          %p 商品詳細
+          .exhibision__content__box__detail--name
+            カテゴリー
+            %span 必須
+          .exhibision__content__box__detail--select
+            = f.collection_select :category_id, @category, :id, :name,{prompt: "選択してください"},{ id: "category_select", class: "exhibision__content__box__detail--select--form"}
+          .exhibision__content__box__detail--brand
+            ブランド
+            %span 任意
+          .exhibision__content__box__detail--form
+            = f.text_field :brand, class:"exhibision__content__box__detail--form--input", placeholder: "例) シャネル"
+          .exhibision__content__box__detail--name
+            商品の状態
+            %span 必須
+          .exhibision__content__box__detail--state
+            = f.collection_select( :item_status_id, ItemStatus.all, :id, :name, {prompt: "選択してください"}, {class: "exhibision__content__box__detail--status-form"})
+        .exhibision__content__box__shipment
+          .exhibision__content__box__shipment--name
+            配送料の負担
+            %span 必須
+          .exhibision__content__box__shipment--select
+            = f.collection_select( :shipment_fee_id, ShipmentFee.all, :id, :name, {prompt: "選択してください"}, {class: "exhibision__content__box__shipment-fee-form"})
+          .exhibision__content__box__shipment--name
+            発送元の地域
+            %span 必須
+          .exhibision__content__box__shipment--select
+            = f.collection_select( :shipment_pref_id, ShipmentPref.all, :id, :name, {prompt: "選択してください"}, {class: "exhibision__content__box__shipment-pref-form"})
+          .exhibision__content__box__shipment--name
+            発送日までの日数
+            %span 必須
+          .exhibision__content__box__shipment--select
+            = f.collection_select( :shipment_date_id, ShipmentDate.all, :id, :name, {prompt: "選択してください"}, {class: "exhibision__content__box__shipment--date-form"})
+        .exhibision__content__box__price
+          .exhibision__content__box__price--name
+            販売価格
+            %span 必須
+          .exhibision__content__box__price--select
+            ￥
+            = f.number_field :price ,placeholder: "0"
+        .exhibision__content__box__sent  
+          = f.submit "出品する"
+
+
+= render "users/footer"        

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -3,7 +3,7 @@
     =render "users/logo"
 
   .exhibision__content
-    = form_with model: @item do |f|
+    = form_with model: @item, local: true do |f|
       .exhibision__content__box
         .exhibision__content__box__image
           .exhibision__content__box__image--name
@@ -18,9 +18,8 @@
             #file-box
               = f.fields_for :images do |image|
                 .js-file_group{data: {index: image.index}}
-
                   = image.label :image, data: {index: image.index} do
-                    = image.file_field :image, class: 'js-file '
+                    = image.file_field :url, class: 'js-file '
                   %span.js-remove 削除
 
                 - if @item.persisted?
@@ -33,7 +32,6 @@
                   = f.label :image, data: {index: lastIndex} do
                     = f.file_field :url, name: "item[images_attributes][#{lastIndex}][url]", class: 'js-file '
                   %span.js-remove 削除
-
         .exhibision__content__box--item
           .exhibision__content__box--item--name
             商品名
@@ -56,8 +54,6 @@
               = f.select :category_id, options_for_select(@category_child_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.parent.id), {}, {class: 'exhibision__content__box__detail--select__box', id: 'child_category'}
             #grandchildren_wrapper.exhibision__content__box__detail--select
               = f.select :category_id, options_for_select(@category_grandchild_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.id), {}, {class: 'exhibision__content__box__detail--select__box', id: 'grandchild_category'}
-          
-          
           .exhibision__content__box__detail--brand
             ブランド
             %span 任意
@@ -92,7 +88,7 @@
             ￥
             = f.number_field :price ,placeholder: "0"
         .exhibision__content__box__sent  
-          = f.submit "出品する"
+          = f.submit "編集する"
 
 
 = render "users/footer"        

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -14,8 +14,7 @@
             #previews
               - if @item.persisted?
                 - @item.images.each_with_index do |image, i|
-                  - id_str = 'image-' + (i).to_s
-                  = image_tag image.url.url, id: id_str ,data: {index: i}, width: '100', height: '100'
+                  = image_tag image.url.url, data: {index: i}, width: '100', height: '100'
             #file-box
               = f.fields_for :images do |image|
                 .js-file_group{data: {index: image.index}}
@@ -52,7 +51,13 @@
             カテゴリー
             %span 必須
           .exhibision__content__box__detail--select
-            = f.collection_select :category_id, @category, :id, :name,{prompt: "選択してください"},{ id: "category_select", class: "exhibision__content__box__detail--select--form"}
+            = f.select :category_id, options_for_select(@category_parent_array.map{|c|[c[:name], c[:id],{'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.parent.parent.id), {}, {class: 'exhibision__content__box__detail--select__box', id: 'category_select'}
+            #children_wrapper.exhibision__content__box__detail--select
+              = f.select :category_id, options_for_select(@category_child_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.parent.id), {}, {class: 'exhibision__content__box__detail--select__box', id: 'child_category'}
+            #grandchildren_wrapper.exhibision__content__box__detail--select
+              = f.select :category_id, options_for_select(@category_grandchild_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.id), {}, {class: 'exhibision__content__box__detail--select__box', id: 'grandchild_category'}
+          
+          
           .exhibision__content__box__detail--brand
             ブランド
             %span 任意

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -137,7 +137,7 @@
                 .details
                   %ul
                     %li
-                      = item.price
+                      = item.price.to_s(:delimited)
                       = "円"
                     %li
                       %i.fa.fa-star.likeIcon
@@ -166,7 +166,7 @@
                 .details
                   %ul
                     %li 
-                      = item.price
+                      = item.price.to_s(:delimited)
                       = "円"
                     %li
                       %i.fa.fa-star.likeIcon

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -109,6 +109,16 @@
               %tr
                 %th 発送日の目安
                 %td 4~7日で目安
+            - if user_signed_in? && current_user.id == @item.seller_id
+              = link_to edit_item_path(@item), class: "btn"  do
+                編集する
+              ／
+              = link_to "#",method: :delete, class: "btn"  do
+                削除する
+            - else
+              .buy__link
+                = link_to  "購入画面へすすむ", "#" 
+
           .option
             %ul
               %li#likebtn.optional-btn.likebtn


### PR DESCRIPTION
## What
[編集画面](https://gyazo.com/9fddf183299ea35bfa1b7d7bae112629)
[編集画面2](https://gyazo.com/81b464f81f75a6ad1cdc67b7356df2c0)
[編集画面3](https://gyazo.com/a63040e4c67900a127c155fe8a38f603)
[編集画面4](https://gyazo.com/0c134808f9d74692c8bb3131758c88cd)
[詳細画面カテゴリ機能](https://gyazo.com/5704a92953083e77d4509ac442318f8e)
### 商品編集機能の実装
#### 保存できない場合はフラッシュメモリーで表示
#### 出品した商品の情報を引き継ぐ
### カテゴリ機能の実装
#### 商品詳細の画面で表示できるようにする
#### セレクトボタンで選択できるように(非同期通信)

## Why
#### 出品した商品を編集するため
#### 元々カテゴリ機能がほぼ出来上がっていたので、作成。商品の詳細ページで表示できるように実装。編集ページへ実装する際にもデータを引き継ぐよう実装した。