### PR TITLE
商品の削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:edit, :update, :show, :destory]
+  before_action :set_item, only: [:edit, :update, :show, :destroy]
 
   def index
     @items = Item.includes(:images)
@@ -56,14 +56,10 @@ class ItemsController < ApplicationController
   end  
 
   def destroy
-    if user_signed_in? && current_user.id == @item.seller_id
-      if @item.destroy
-        redirect_to root_path, notice: '削除が完了しました'
-      else
-        redirect_to root_path, alert: '削除できませんでした'
-      end
+    if @item.destroy
+      redirect_to root_path, notice: '削除が完了しました'
     else
-      redirect_to root_path, alert: '権限がありません'
+      redirect_to root_path, alert: '削除できませんでした'
     end
   end
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -22,7 +22,6 @@
             ブランド
       %ul.lists__right
         - if user_signed_in? && current_user.id == @item.seller_id
-
           %li.lists__right__item-new
             = link_to "マイページ", "/users/show"
             = link_to "編集", edit_item_path(@item.id)


### PR DESCRIPTION
## what
[削除画面](https://gyazo.com/74c7b110ab360413569aa44766e4208f)
### 商品の削除機能の実装
#### 出品者にしか削除ボタンを表示させないようにした

## why
#### 商品を削除できるようにするため
#### 出品者以外はログインボタンまたは購入ボタンを表示させるようにした
#### 削除が成功した場合は"削除が完了しましたし"と表示
#### 削除に失敗した場合は"削除ができませんでした"と表示